### PR TITLE
Fix / Synchronize Lidar Frames with Ouster Definitions

### DIFF
--- a/ouster_description/launch/os_world.launch
+++ b/ouster_description/launch/os_world.launch
@@ -7,10 +7,10 @@
   <arg name="debug" default="false"/>
   <arg name="verbose" default="false"/>
   <arg name="world_name" default="$(find ouster_description)/worlds/example.world"/>
-  <arg name="model" default="$(find ouster_description)/urdf/example.urdf.xacro"/>
+  <arg name="model" default="$(find ouster_description)/urdf/OS1-64.urdf.xacro"/>
 
   <!-- Start gazebo and load the world -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch" >
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="paused" value="$(arg paused)"/>
     <arg name="use_sim_time" value="$(arg use_sim_time)"/>
     <arg name="gui" value="$(arg gui)"/>
@@ -21,15 +21,13 @@
   </include>
 
   <!-- Spawn the example robot -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg model)'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg model)'"/>
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_sensor" output="screen" args="-urdf -param robot_description -model example"/>
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
-    <param name="publish_frequency" type="double" value="30.0" />
+    <param name="publish_frequency" type="double" value="30.0"/>
   </node>
 
   <!-- RViz -->
   <arg name="rviz" default="true"/>
-  <node if="$(arg rviz)" pkg="rviz" type="rviz" name="$(anon rviz)" respawn="false" output="screen" args="-d $(find ouster_description)/rviz/example.rviz" />
- 
-
+  <node if="$(arg rviz)" pkg="rviz" type="rviz" name="$(anon rviz)" respawn="false" output="screen" args="-d $(find ouster_description)/rviz/example.rviz"/>
 </launch>

--- a/ouster_description/launch/os_world.launch
+++ b/ouster_description/launch/os_world.launch
@@ -7,7 +7,8 @@
   <arg name="debug" default="false"/>
   <arg name="verbose" default="false"/>
   <arg name="world_name" default="$(find ouster_description)/worlds/example.world"/>
-  <arg name="model" default="$(find ouster_description)/urdf/OS1-64.urdf.xacro"/>
+  <arg name="model" default="$(find ouster_description)/urdf/example.urdf.xacro"/>
+  <arg name="ouster_type" default="OS0-32"/>
 
   <!-- Start gazebo and load the world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
@@ -21,7 +22,7 @@
   </include>
 
   <!-- Spawn the example robot -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg model)'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg model)' ouster_type:='$(arg ouster_type)'"/>
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_sensor" output="screen" args="-urdf -param robot_description -model example"/>
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="30.0"/>

--- a/ouster_description/rviz/example.rviz
+++ b/ouster_description/rviz/example.rviz
@@ -4,8 +4,9 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
+        - /Global Options1
         - /TF1/Frames1
-      Splitter Ratio: 0.5
+      Splitter Ratio: 0.644444465637207
     Tree Height: 546
   - Class: rviz/Selection
     Name: Selection
@@ -22,12 +23,13 @@ Panels:
     Name: Views
     Splitter Ratio: 0.5
   - Class: rviz/Time
-    Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: OS1-64
+    SyncSource: OS PointCloud
 Preferences:
   PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
 Visualization Manager:
   Class: ""
   Displays:
@@ -51,19 +53,26 @@ Visualization Manager:
       Value: true
     - Class: rviz/TF
       Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
       Frame Timeout: 15
       Frames:
-        All Enabled: true
+        All Enabled: false
         base_footprint:
-          Value: true
+          Value: false
         base_link:
+          Value: false
+        os0_imu:
           Value: true
-        os_imu:
+        os0_lidar:
           Value: true
-        os_lidar:
+        os0_sensor:
           Value: true
-        os_sensor:
+        os0_sensor_base_link:
           Value: true
+        os0_sensor_baseplate:
+          Value: true
+      Marker Alpha: 1
       Marker Scale: 1
       Name: TF
       Show Arrows: true
@@ -72,11 +81,13 @@ Visualization Manager:
       Tree:
         base_footprint:
           base_link:
-            os_sensor:
-              os_imu:
-                {}
-              os_lidar:
-                {}
+            os0_sensor_base_link:
+              os0_sensor_baseplate:
+                os0_sensor:
+                  os0_imu:
+                    {}
+                  os0_lidar:
+                    {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -98,15 +109,24 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        os_imu:
+        os0_imu:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        os_lidar:
+        os0_lidar:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        os_sensor:
+        os0_sensor:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        os0_sensor_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        os0_sensor_baseplate:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -132,17 +152,15 @@ Visualization Manager:
       Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: -999999
       Min Color: 0; 0; 0
-      Min Intensity: 999999
-      Name: OS1-64
+      Name: OS PointCloud
       Position Transformer: XYZ
       Queue Size: 10
       Selectable: true
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Flat Squares
-      Topic: /os_cloud_node/points
+      Topic: /ouster/points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
@@ -162,7 +180,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -172,25 +193,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/XYOrbit
-      Distance: 4.091195106506348
+      Distance: 3.7436485290527344
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
+      Field of View: 0.7853981852531433
       Focal Point:
-        X: -0.3465893268585205
-        Y: 0.821905255317688
-        Z: 0
+        X: 0.686415433883667
+        Y: -0.36081576347351074
+        Z: -1.385807991027832e-06
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.44039908051490784
+      Pitch: 0.5853989720344543
       Target Frame: <Fixed Frame>
-      Value: XYOrbit (rviz)
-      Yaw: 5.6336212158203125
+      Yaw: 2.4236209392547607
     Saved: ~
 Window Geometry:
   Displays:
@@ -198,7 +219,7 @@ Window Geometry:
   Height: 843
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002adfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002ad000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000002c4000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002eb00fffffffb0000000800540069006d0065010000000000000450000000000000000000000340000002ad00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002adfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002ad000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002c4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000002c4000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000003bc00fffffffb0000000800540069006d0065010000000000000450000000000000000000000340000002ad00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -209,4 +230,4 @@ Window Geometry:
     collapsed: true
   Width: 1200
   X: 400
-  Y: 27
+  Y: 0

--- a/ouster_description/urdf/OS0-32.urdf.xacro
+++ b/ouster_description/urdf/OS0-32.urdf.xacro
@@ -1,7 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="OS0-32">
   <xacro:property name="M_PI" value="3.1415926535897931" />
-  <xacro:macro name="OS0-32" params="*origin parent:=base_link name:=os0_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=32 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os0_lidar imu_link:=os0_imu vfov_min:=-0.785398 vfov_max:=0.785398">
+  <xacro:property name="rev6_lidar_z" value="0.03622"/>
+  <xacro:property name="rev7_lidar_z" value="0.038195"/>
+
+  <xacro:macro name="OS0-32" params="rev:=rev6 *origin parent:=base_link name:=os0_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=32 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os0_lidar imu_link:=os0_imu vfov_min:=-0.785398 vfov_max:=0.785398">
+
+    <xacro:if value="${rev == 'rev6'}">
+      <xacro:property name="lidar_z" value="${rev6_lidar_z}"/>
+    </xacro:if>
+    <xacro:if value="${rev == 'rev7'}">
+      <xacro:property name="lidar_z" value="${rev7_lidar_z}"/>
+    </xacro:if>
 
     <joint name="${name}_mount_joint" type="fixed">
       <xacro:insert_block name="origin" />
@@ -78,7 +88,7 @@
     <joint name="${name}_lidar_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${lidar_link}" />
-      <origin xyz="0 0 0.03618" rpy="0 0 ${M_PI}" />
+      <origin xyz="0 0 ${lidar_z}" rpy="0 0 ${M_PI}" />
     </joint>
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->

--- a/ouster_description/urdf/OS0-32.urdf.xacro
+++ b/ouster_description/urdf/OS0-32.urdf.xacro
@@ -33,10 +33,11 @@
       </collision>
     </link>
 
+    <!-- The "sensor frame" is centered at the bottom of the sensor body with x pointing forward away from the plug (see Ouster user manaual (https://data.ouster.io/downloads/software-user-manual/software-user-manual-v2p0.pdf#e))-->
     <joint name="${name}_baseplate_to_body" type="fixed">
       <parent link="${name}_baseplate"/>
       <child link="${name}"/>
-      <origin xyz="0 0 0.042" rpy="0 0 0" />
+      <origin xyz="0 0 0.008" rpy="0 0 0" />
     </joint>
 
     <link name="${name}">
@@ -53,10 +54,9 @@
          </geometry>
       </collision>
       <visual name="base_visual">
-         <origin xyz="0 0 0.0" rpy="0 0 1.5707" />
+         <origin xyz="0 0 0.03618" rpy="0 0 1.5707" />
          <geometry>
 	         <mesh filename="package://ouster_description/meshes/os1_64.dae" />
-           <!-- <cylinder length="0.073" radius="0.04" /> -->
          </geometry>
       </visual>
     </link>
@@ -65,7 +65,7 @@
 
     <link name="${lidar_link}" />
 
-
+    <!-- The Ouster driver publishes these joints, however, we must define them here for Gazebo and Robot State Publisher -->
     <joint name="${name}_imu_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${imu_link}" />
@@ -74,10 +74,11 @@
     <gazebo reference="${imu_link}">
     </gazebo>
 
+    <!-- The lidar frame points backwards towards the sensor plug and is vertical centered in the lidar window -->
     <joint name="${name}_lidar_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${lidar_link}" />
-      <origin xyz="0.0 0.0 0.03618" rpy="0 0 0" />
+      <origin xyz="0 0 0.03618" rpy="0 0 ${M_PI}" />
     </joint>
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->

--- a/ouster_description/urdf/OS0-32.urdf.xacro
+++ b/ouster_description/urdf/OS0-32.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="OS0-32">
   <xacro:property name="M_PI" value="3.1415926535897931" />
-  <xacro:macro name="OS0-32" params="*origin parent:=base_link name:=os0_sensor topic_points:=/os0_cloud_node/points topic_imu:=/os0_cloud_node/imu hz:=10 lasers:=32 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os0_lidar imu_link:=os0_imu vfov_min:=-0.785398 vfov_max:=0.785398">
+  <xacro:macro name="OS0-32" params="*origin parent:=base_link name:=os0_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=32 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os0_lidar imu_link:=os0_imu vfov_min:=-0.785398 vfov_max:=0.785398">
 
     <joint name="${name}_mount_joint" type="fixed">
       <xacro:insert_block name="origin" />
@@ -42,22 +42,22 @@
 
     <link name="${name}">
       <inertial>
-         <mass value="0.33"/>
-         <origin xyz="0 0 0.0365" rpy="0 0 0" />
-         <inertia ixx="0.000241148" ixy="0" ixz="0"
-          iyy="0.000241148" iyz="0" izz="0.000264"/>
+        <mass value="0.33"/>
+        <origin xyz="0 0 0.0365" rpy="0 0 0" />
+        <inertia ixx="0.000241148" ixy="0" ixz="0"
+                 iyy="0.000241148" iyz="0" izz="0.000264"/>
       </inertial>
       <collision name="base_collision">
-         <origin xyz="0 0 0.0365" rpy="0 0 0" />
-         <geometry>
+        <origin xyz="0 0 0.0365" rpy="0 0 0" />
+        <geometry>
  	        <cylinder radius="0.04" length="0.073"/>
-         </geometry>
+        </geometry>
       </collision>
       <visual name="base_visual">
-         <origin xyz="0 0 0.03618" rpy="0 0 1.5707" />
-         <geometry>
-	         <mesh filename="package://ouster_description/meshes/os1_64.dae" />
-         </geometry>
+        <origin xyz="0 0 0.03618" rpy="0 0 1.5707" />
+        <geometry>
+          <mesh filename="package://ouster_description/meshes/os1_64.dae" />
+        </geometry>
       </visual>
     </link>
 
@@ -83,56 +83,56 @@
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->
     <gazebo reference="${name}">
-        <sensor type="ray" name="${name}-OS0-32">
-          <pose>0 0 0 0 0 0</pose>
-          <visualize>false</visualize>
-          <update_rate>${hz}</update_rate>
-          <ray>
-            <scan>
-              <horizontal>
-                <samples>${samples}</samples>
-                <resolution>1</resolution>
-                <min_angle>${min_angle}</min_angle>
-                <max_angle>${max_angle}</max_angle>
-              </horizontal>
-              <vertical>
-                <samples>${lasers}</samples>
-                <resolution>1</resolution>
-                <min_angle>${vfov_min}</min_angle>
-                <max_angle>${vfov_max}</max_angle>
-              </vertical>
-            </scan>
-            <range>
-              <min>${min_range}</min>
-              <max>${max_range}</max>
-              <resolution>0.03</resolution>
-            </range>
-          </ray>
-          <plugin name="gazebo_ros_laser_controller" filename="libgazebo_ros_ouster_laser.so">
-            <topicName>${topic_points}</topicName>
-            <frameName>${lidar_link}</frameName>
-            <min_range>${min_range}</min_range>
-            <max_range>${max_range}</max_range>
-            <gaussianNoise>${noise}</gaussianNoise>
-          </plugin>
-        </sensor>
+      <sensor type="ray" name="${name}-OS0-32">
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>${hz}</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>${samples}</samples>
+              <resolution>1</resolution>
+              <min_angle>${min_angle}</min_angle>
+              <max_angle>${max_angle}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>${lasers}</samples>
+              <resolution>1</resolution>
+              <min_angle>${vfov_min}</min_angle>
+              <max_angle>${vfov_max}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${min_range}</min>
+            <max>${max_range}</max>
+            <resolution>0.03</resolution>
+          </range>
+        </ray>
+        <plugin name="gazebo_ros_laser_controller" filename="libgazebo_ros_ouster_laser.so">
+          <topicName>${topic_points}</topicName>
+          <frameName>${lidar_link}</frameName>
+          <min_range>${min_range}</min_range>
+          <max_range>${max_range}</max_range>
+          <gaussianNoise>${noise}</gaussianNoise>
+        </plugin>
+      </sensor>
     </gazebo>
 
     <!-- IMU -->
-  <gazebo>
-    <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
-      <robotNamespace>/</robotNamespace>
-      <updateRate>100.0</updateRate>
-      <bodyName>${imu_link}</bodyName>
-      <topicName>${topic_imu}</topicName>
-      <accelDrift>0.005 0.005 0.005</accelDrift>
-      <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
-      <rateDrift>0.005 0.005 0.005 </rateDrift>
-      <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
-      <headingDrift>0.005</headingDrift>
-      <headingGaussianNoise>0.005</headingGaussianNoise>
-    </plugin>
-  </gazebo>
+    <gazebo>
+      <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
+        <robotNamespace>/</robotNamespace>
+        <updateRate>100.0</updateRate>
+        <bodyName>${imu_link}</bodyName>
+        <topicName>${topic_imu}</topicName>
+        <accelDrift>0.005 0.005 0.005</accelDrift>
+        <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
+        <rateDrift>0.005 0.005 0.005 </rateDrift>
+        <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
+        <headingDrift>0.005</headingDrift>
+        <headingGaussianNoise>0.005</headingGaussianNoise>
+      </plugin>
+    </gazebo>
 
   </xacro:macro>
 </robot>

--- a/ouster_description/urdf/OS1-64.urdf.xacro
+++ b/ouster_description/urdf/OS1-64.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="OS1-64">
   <xacro:property name="M_PI" value="3.1415926535897931" />
-  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os_lidar imu_link:=os_imu vfov_min:=-.26 vfov_max:=.26">
+  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os1_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os1_lidar imu_link:=os1_imu vfov_min:=-.26 vfov_max:=.26">
 
     <joint name="${name}_mount_joint" type="fixed">
       <xacro:insert_block name="origin" />
@@ -42,22 +42,22 @@
 
     <link name="${name}">
       <inertial>
-         <mass value="0.33"/>
-         <origin xyz="0 0 0.0365" rpy="0 0 0" />
-         <inertia ixx="0.000241148" ixy="0" ixz="0"
-          iyy="0.000241148" iyz="0" izz="0.000264"/>
+        <mass value="0.33"/>
+        <origin xyz="0 0 0.0365" rpy="0 0 0" />
+        <inertia ixx="0.000241148" ixy="0" ixz="0"
+                 iyy="0.000241148" iyz="0" izz="0.000264"/>
       </inertial>
       <collision name="base_collision">
-         <origin xyz="0 0 0.0365" rpy="0 0 0" />
-         <geometry>
+        <origin xyz="0 0 0.0365" rpy="0 0 0" />
+        <geometry>
  	        <cylinder radius="0.04" length="0.073"/>
-         </geometry>
+        </geometry>
       </collision>
       <visual name="base_visual">
-         <origin xyz="0 0 0.03618" rpy="0 0 1.5707" />
-         <geometry>
-	         <mesh filename="package://ouster_description/meshes/os1_64.dae" />
-         </geometry>
+        <origin xyz="0 0 0.03618" rpy="0 0 1.5707" />
+        <geometry>
+	        <mesh filename="package://ouster_description/meshes/os1_64.dae" />
+        </geometry>
       </visual>
     </link>
 
@@ -71,8 +71,6 @@
       <child link="${imu_link}" />
       <origin xyz="0.006253 -0.011775 0.007645" rpy="0 0 0" />
     </joint>
-    <gazebo reference="${imu_link}">
-    </gazebo>
 
     <!-- The lidar frame points backwards towards the sensor plug and is vertical centered in the lidar window -->
     <joint name="${name}_lidar_link_joint" type="fixed">
@@ -83,56 +81,56 @@
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->
     <gazebo reference="${name}">
-        <sensor type="ray" name="${name}-OS1-64">
-          <pose>0 0 0 0 0 0</pose>
-          <visualize>false</visualize>
-          <update_rate>${hz}</update_rate>
-          <ray>
-            <scan>
-              <horizontal>
-                <samples>${samples}</samples>
-                <resolution>1</resolution>
-                <min_angle>${min_angle}</min_angle>
-                <max_angle>${max_angle}</max_angle>
-              </horizontal>
-              <vertical>
-                <samples>${lasers}</samples>
-                <resolution>1</resolution>
-                <min_angle>${vfov_min}</min_angle>
-                <max_angle>${vfov_max}</max_angle>
-              </vertical>
-            </scan>
-            <range>
-              <min>${min_range}</min>
-              <max>${max_range}</max>
-              <resolution>0.03</resolution>
-            </range>
-          </ray>
-          <plugin name="gazebo_ros_laser_controller" filename="libgazebo_ros_ouster_laser.so">
-            <topicName>${topic_points}</topicName>
-            <frameName>${lidar_link}</frameName>
-            <min_range>${min_range}</min_range>
-            <max_range>${max_range}</max_range>
-            <gaussianNoise>${noise}</gaussianNoise>
-          </plugin>
-        </sensor>
+      <sensor type="ray" name="${name}-OS1-64">
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>${hz}</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>${samples}</samples>
+              <resolution>1</resolution>
+              <min_angle>${min_angle}</min_angle>
+              <max_angle>${max_angle}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>${lasers}</samples>
+              <resolution>1</resolution>
+              <min_angle>${vfov_min}</min_angle>
+              <max_angle>${vfov_max}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${min_range}</min>
+            <max>${max_range}</max>
+            <resolution>0.03</resolution>
+          </range>
+        </ray>
+        <plugin name="gazebo_ros_laser_controller" filename="libgazebo_ros_ouster_laser.so">
+          <topicName>${topic_points}</topicName>
+          <frameName>${lidar_link}</frameName>
+          <min_range>${min_range}</min_range>
+          <max_range>${max_range}</max_range>
+          <gaussianNoise>${noise}</gaussianNoise>
+        </plugin>
+      </sensor>
     </gazebo>
 
     <!-- IMU -->
-  <gazebo>
-    <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
-      <robotNamespace>/</robotNamespace>
-      <updateRate>100.0</updateRate>
-      <bodyName>${imu_link}</bodyName>
-      <topicName>${topic_imu}</topicName>
-      <accelDrift>0.005 0.005 0.005</accelDrift>
-      <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
-      <rateDrift>0.005 0.005 0.005 </rateDrift>
-      <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
-      <headingDrift>0.005</headingDrift>
-      <headingGaussianNoise>0.005</headingGaussianNoise>
-    </plugin>
-  </gazebo>
+    <gazebo>
+      <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
+        <robotNamespace>/</robotNamespace>
+        <updateRate>100.0</updateRate>
+        <bodyName>${imu_link}</bodyName>
+        <topicName>${topic_imu}</topicName>
+        <accelDrift>0.005 0.005 0.005</accelDrift>
+        <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
+        <rateDrift>0.005 0.005 0.005 </rateDrift>
+        <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
+        <headingDrift>0.005</headingDrift>
+        <headingGaussianNoise>0.005</headingGaussianNoise>
+      </plugin>
+    </gazebo>
 
   </xacro:macro>
 </robot>

--- a/ouster_description/urdf/OS1-64.urdf.xacro
+++ b/ouster_description/urdf/OS1-64.urdf.xacro
@@ -1,7 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="OS1-64">
   <xacro:property name="M_PI" value="3.1415926535897931" />
-  <xacro:macro name="OS1-64" params="*origin parent:=base_link name:=os1_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os1_lidar imu_link:=os1_imu vfov_min:=-.26 vfov_max:=.26">
+  <xacro:property name="rev6_lidar_z" value="0.03622"/>
+  <xacro:property name="rev7_lidar_z" value="0.038195"/>
+
+  <xacro:macro name="OS1-64" params="rev:=rev6 *origin parent:=base_link name:=os1_sensor topic_points:=/ouster/points topic_imu:=/ouster/imu hz:=10 lasers:=64 samples:=512 min_range:=0.9 max_range:=75.0 noise:=0.008 min_angle:=-${M_PI} max_angle:=${M_PI} lidar_link:=os1_lidar imu_link:=os1_imu vfov_min:=-.26 vfov_max:=.26">
+
+    <xacro:if value="${rev == 'rev6'}">
+      <xacro:property name="lidar_z" value="${rev6_lidar_z}"/>
+    </xacro:if>
+    <xacro:if value="${rev == 'rev7'}">
+      <xacro:property name="lidar_z" value="${rev7_lidar_z}"/>
+    </xacro:if>
 
     <joint name="${name}_mount_joint" type="fixed">
       <xacro:insert_block name="origin" />
@@ -76,7 +86,7 @@
     <joint name="${name}_lidar_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${lidar_link}" />
-      <origin xyz="0 0 0.03618" rpy="0 0 ${M_PI}" />
+      <origin xyz="0 0 ${lidar_z}" rpy="0 0 ${M_PI}" />
     </joint>
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->

--- a/ouster_description/urdf/OS1-64.urdf.xacro
+++ b/ouster_description/urdf/OS1-64.urdf.xacro
@@ -33,10 +33,11 @@
       </collision>
     </link>
 
+    <!-- The "sensor frame" is centered at the bottom of the sensor body with x pointing forward away from the plug (see Ouster user manaual (https://data.ouster.io/downloads/software-user-manual/software-user-manual-v2p0.pdf#e))-->
     <joint name="${name}_baseplate_to_body" type="fixed">
       <parent link="${name}_baseplate"/>
       <child link="${name}"/>
-      <origin xyz="0 0 0.042" rpy="0 0 0" />
+      <origin xyz="0 0 0.008" rpy="0 0 0" />
     </joint>
 
     <link name="${name}">
@@ -53,10 +54,9 @@
          </geometry>
       </collision>
       <visual name="base_visual">
-         <origin xyz="0 0 0.0" rpy="0 0 1.5707" />
+         <origin xyz="0 0 0.03618" rpy="0 0 1.5707" />
          <geometry>
 	         <mesh filename="package://ouster_description/meshes/os1_64.dae" />
-           <!-- <cylinder length="0.073" radius="0.04" /> -->
          </geometry>
       </visual>
     </link>
@@ -65,7 +65,7 @@
 
     <link name="${lidar_link}" />
 
-
+    <!-- The Ouster driver publishes these joints, however, we must define them here for Gazebo and Robot State Publisher -->
     <joint name="${name}_imu_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${imu_link}" />
@@ -74,10 +74,11 @@
     <gazebo reference="${imu_link}">
     </gazebo>
 
+    <!-- The lidar frame points backwards towards the sensor plug and is vertical centered in the lidar window -->
     <joint name="${name}_lidar_link_joint" type="fixed">
       <parent link="${name}" />
       <child link="${lidar_link}" />
-      <origin xyz="0.0 0.0 0.03618" rpy="0 0 0" />
+      <origin xyz="0 0 0.03618" rpy="0 0 ${M_PI}" />
     </joint>
 
     <!-- Gazebo requires the ouster_gazebo_plugins package -->

--- a/ouster_description/urdf/example.urdf.xacro
+++ b/ouster_description/urdf/example.urdf.xacro
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="os1_example">
 
+  <!-- Arg for selecting Ouster type -->
+  <xacro:arg name="ouster_type" default="OS1-64"/>
+  <xacro:property name="ouster_type" value="$(arg ouster_type)"/>
+
   <!-- Base Footprint -->
   <link name="base_footprint" />
 
@@ -30,9 +34,18 @@
     </inertial>
   </link>
 
+  <xacro:include filename="$(find ouster_description)/urdf/OS0-32.urdf.xacro"/>
   <xacro:include filename="$(find ouster_description)/urdf/OS1-64.urdf.xacro"/>
-  <OS1-64 parent="base_link" name="os1_sensor" hz="10" samples="220">
-    <origin xyz="0 0 1.2" rpy="0 0 0" />
-  </OS1-64>
 
+  <xacro:if value="${ouster_type == 'OS0-32'}">
+    <xacro:OS0-32 parent="base_link" name="os0_sensor" hz="10" samples="512">
+      <origin xyz="0 0 1.2" rpy="0 0 0" />
+    </xacro:OS0-32>
+  </xacro:if>
+
+  <xacro:if value="${ouster_type == 'OS1-64'}">
+    <xacro:OS1-64 parent="base_link" name="os1_sensor" hz="10" samples="512">
+      <origin xyz="0 0 1.2" rpy="0 0 0" />
+    </xacro:OS1-64>
+  </xacro:if>
 </robot>

--- a/ouster_description/urdf/example.urdf.xacro
+++ b/ouster_description/urdf/example.urdf.xacro
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="os1_example">
+
+  <!-- Base Footprint -->
+  <link name="base_footprint" />
+
+  <!-- Base Link -->
+  <joint name="footprint" type="fixed" >
+   <parent link="base_footprint" />
+    <child link="base_link" />
+    <origin xyz="0 0 0.05" rpy="0 0 0" />
+  </joint>
+  <link name="base_link" >
+    <visual>
+      <geometry>
+        <box size="0.5 0.5 0.1" />
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.5 0.5 0.1" />
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0"/>
+      <mass value="10"/>
+      <inertia ixx="3.0" ixy="0.0" ixz="0.0"
+               iyy="3.0" iyz="0.0"
+               izz="3.0" />
+    </inertial>
+  </link>
+
+  <xacro:include filename="$(find ouster_description)/urdf/OS1-64.urdf.xacro"/>
+  <OS1-64 parent="base_link" name="os1_sensor" hz="10" samples="220">
+    <origin xyz="0 0 1.2" rpy="0 0 0" />
+  </OS1-64>
+
+</robot>


### PR DESCRIPTION
This PR fixes the location of the `*_sensor` and `*_lidar` frames so that they match the definitions provided by Ouster in their [Software User Manual](https://data.ouster.io/downloads/software-user-manual/software-user-manual-v2p0.pdf#e). This PR also it possible to spawn and view different Ouster models in Gazebo and Rviz. 